### PR TITLE
Add encryption key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ KV is a secure and lightweight command-line key-value store built in Go.
 ## Features
 - Key-value pair storage with optional buckets
 - AES-256 encryption for all values
+- Shared encryption key or separate encryption key for each bucket
 - Import key-value from the AWS SSM Parameters service
 - Read key value from a file, STDIN or plain tex
 
@@ -28,7 +29,8 @@ kv [command] [flags]
 
 ### Commands
 
-- `kv add <key>|<key@bucket> <value>` – Add or update a value
+- `kv add key <key>|<key@bucket> <value>` – Add or update a value
+- `kv add bucket <name> - add a bucket`
 - `kv get <key>|<key@bucket>` – Retrieve a value
 - `kv list keys [<bucket>]` – List keys in the default or specified bucket
 - `kv list buckets` – List all available buckets
@@ -65,12 +67,19 @@ kv completion zsh > "${HOME}/.zsh_completions/_kv"
 ```
 
 ### Examples
-#### Add:
+#### Add bucket:
 ```shell
-kv add my-key my-value # add KV to the default bucket
-kv add my-key@prod my-value # add KV to the `prod` bucket
-kv add longtext @readme.txt # read value from file
-echo 'env=prod' | kv add config@env @- # read value from stdin
+kv add bucket prod-secrets # create a bucket with a default encryption key
+kv add bucket prod-secret --generate-new-key # create a bucket with a separate encryption key
+```
+#### Add key:
+IMPORTANT: If the bucket does not exist, a new bucket will be created using the default encryption key.
+           If you need a separate encryption key for the bucket, add a new bucket before KV.
+```shell
+kv add key my-key my-value # add KV to the default bucket
+kv add key my-key@prod my-value # add KV to the `prod` bucket
+kv add key longtext @readme.txt # read value from file
+echo 'env=prod' | kv add key config@env @- # read value from stdin
 ```
 #### Get:
 ```shell
@@ -147,7 +156,7 @@ kv import ssm --bucket=mybucket --dry-run --show-values /prod
 ## Configuration
 
 > IMPORTANT:
-> On first start, a new encryption key will be generated and saved to a file.
+> On first start, a default encryption key will be generated and saved to a file.
 >
 > You cannot change the encryption key for existing key-value records.
 
@@ -157,7 +166,7 @@ You can set encryption and DB path using CLI flags or environment variables:
 |------------------------|-------------------------|-----------------------------|-----------|
 | Database path          | `--db`                  | `KV_DB_PATH`                | ~/.kv.db  |
 | Encryption key         | `--encryption-key`      | `KV_ENCRYPTION_KEY`         | ""        |
-| Encryption key file    | `--encryption-key-file` | `KV_ENCRYPTION_KEY_FILE`    | ~/.kv.key |
+| Encryption key store   | `--encryption-key-store`| `KV_ENCRYPTION_KEY_STORE`   | ~/.kv.key |
 
 If no key is provided, a new one is automatically generated and stored in the file by path `~/.kv.key`.
 

--- a/cmd/kv/cmd/add.go
+++ b/cmd/kv/cmd/add.go
@@ -1,72 +1,19 @@
 package cmd
 
 import (
-	"fmt"
-	"io"
-	"os"
-	"strings"
-
-	"github.com/yousysadmin/kv/internal/storage"
-
 	"github.com/spf13/cobra"
 )
 
 // addCmd represents the add command
 var addCmd = &cobra.Command{
-	Use:   "add <key>|<key@bucket> <value>",
-	Short: "Add or update a key-value pair.",
-	Long: `This command encrypts and stores the provided value using the configured AES key.
-You can specify the encryption key via the --encryption-key flag or the --encryption-key-file option.
-
-Arguments:
-  <key>         The key to store the value under in the default bucket.
-  <key@bucket>  The key to store in a specific named bucket.
-  <value>       The value to be encrypted and stored.`,
+	Use:   "add",
+	Short: "Add keys or buckets to the store",
+	Long:  "The add command adding keys or buckets to the store.",
 	Example: `
-  kv add username admin
-  kv add password@auth supersecret
-  kv add config@prod '{"debug":false}'
-  kv add longtext @readme.txt
-  echo 'env=prod' | kv add config@env @-`,
-	Args: cobra.MatchAll(cobra.ExactArgs(2), cobra.OnlyValidArgs),
-	Run: func(cmd *cobra.Command, args []string) {
-		k, b := parseKey(args[0])
-		s := storage.NewEntityStorage(db, encryptionKey)
-		val, err := readValue(args[1])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "add key: %s failed: %s\n", k, err.Error())
-			os.Exit(1)
-		}
-		err = s.Add(b, k, val)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "add key: %s failed: %s\n", k, err.Error())
-			os.Exit(1)
-		}
-
-		fmt.Printf("add key: %s successfully\n", k)
-	},
-}
-
-// readValue interprets a value argument, supporting:
-// plain string
-// @filename to read content from a file
-// @- to read content from stdin
-func readValue(arg string) (string, error) {
-	if strings.HasPrefix(arg, "@") {
-		if arg == "@-" {
-			data, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return "", fmt.Errorf("failed to read from stdin: %w", err)
-			}
-			return string(data), nil
-		}
-		data, err := os.ReadFile(arg[1:])
-		if err != nil {
-			return "", fmt.Errorf("failed to read file %s: %w", arg[1:], err)
-		}
-		return string(data), nil
-	}
-	return arg, nil
+  kv add key ...
+  kv add bucket prod`,
+	Args: cobra.NoArgs,
+	//Run: func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {

--- a/cmd/kv/cmd/add_bucket.go
+++ b/cmd/kv/cmd/add_bucket.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yousysadmin/kv/internal/enckeystore"
+	"github.com/yousysadmin/kv/internal/storage"
+
+	"github.com/spf13/cobra"
+)
+
+var generateNewKey bool
+
+// addKeyCmd represents the add key command
+var addBucketCmd = &cobra.Command{
+	Use:   "bucket",
+	Short: "Add bucket.",
+	Long: `This command add a new bucket to the store  and stores.
+
+Arguments:
+  <bucket_nam> [flags]
+
+  <bucket_name> A bucket name.`,
+	Example: `
+  kv add bucket prod-secrets
+  kv add bucket prod-secret --generate-new-key # for create a bucket with a separate encryption key`,
+	Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run: func(cmd *cobra.Command, args []string) {
+		bucket := args[0]
+
+		s := storage.NewEntityStorage(kvdb, "")
+
+		// Check bucket exist
+		if exist, err := s.BucketExist(bucket); err != nil || exist {
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			fmt.Printf("bucket %q exist\n", bucket)
+			os.Exit(1)
+		}
+
+		// Create a new bucket
+		if err := s.AddBucket(bucket); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// if generate-mew-key is true
+		// generate and save new encryption key to the encryption store
+		if generateNewKey {
+			if encryptionKenStore.HasKey(bucket) {
+				fmt.Printf("Encryption key for the bucket %s is exist", bucket)
+			}
+
+			enckey, err := enckeystore.GenerateEncryptionKey()
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			if err := encryptionKenStore.AddKey(bucket, enckeystore.EncryptionKey(enckey)); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			if err := encryptionKenStore.Save(); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
+
+		fmt.Printf("add bucket: %s successfully\n", bucket)
+	},
+}
+
+func init() {
+	addCmd.AddCommand(addBucketCmd)
+
+	addBucketCmd.PersistentFlags().BoolVar(&generateNewKey, "generate-new-key", false, "Generate a new encryption key for this bucket")
+}

--- a/cmd/kv/cmd/add_key.go
+++ b/cmd/kv/cmd/add_key.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/yousysadmin/kv/internal/storage"
+
+	"github.com/spf13/cobra"
+)
+
+// addKeyCmd represents the add key command
+var addKeyCmd = &cobra.Command{
+	Use:   "key",
+	Short: "Add or update a key-value pair.",
+	Long: `This command encrypts and stores the provided value using the configured AES key.
+You can specify the encryption key via the --encryption-key flag.
+
+Arguments:
+  <key>|<key@bucket> <value>
+
+  <key>         The key to store the value under in the default bucket.
+  <key@bucket>  The key to store in a specific named bucket.
+  <value>       The value to be encrypted and stored.`,
+	Example: `
+  kv add key username admin
+  kv add key password@auth supersecret
+  kv add key config@prod '{"debug":false}'
+  kv add key longtext @readme.txt
+  echo 'env=prod' | kv add key config@env @-`,
+	Args: cobra.MatchAll(cobra.ExactArgs(2), cobra.OnlyValidArgs),
+	Run: func(cmd *cobra.Command, args []string) {
+		k, b := parseKey(args[0])
+
+		encKey, err := selectKey(encryptionKeys, b)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		s := storage.NewEntityStorage(kvdb, encKey)
+		val, err := readValue(args[1])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "add key: %s failed: %s\n", k, err.Error())
+			os.Exit(1)
+		}
+		err = s.Add(b, k, val)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "add key: %s failed: %s\n", k, err.Error())
+			os.Exit(1)
+		}
+
+		fmt.Printf("add key: %s successfully\n", k)
+	},
+}
+
+// readValue interprets a value argument, supporting:
+// plain string
+// @filename to read content from a file
+// @- to read content from stdin
+func readValue(arg string) (string, error) {
+	if strings.HasPrefix(arg, "@") {
+		if arg == "@-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return "", fmt.Errorf("failed to read from stdin: %w", err)
+			}
+			return string(data), nil
+		}
+		data, err := os.ReadFile(arg[1:])
+		if err != nil {
+			return "", fmt.Errorf("failed to read file %s: %w", arg[1:], err)
+		}
+		return string(data), nil
+	}
+	return arg, nil
+}
+
+func init() {
+	addCmd.AddCommand(addKeyCmd)
+}

--- a/cmd/kv/cmd/delete_bucket.go
+++ b/cmd/kv/cmd/delete_bucket.go
@@ -21,7 +21,7 @@ This command removes the specified bucket from the store.`,
 	Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		bucket := args[0]
-		s := storage.NewEntityStorage(db, encryptionKey)
+		s := storage.NewEntityStorage(kvdb, "")
 		err := s.DeleteBucket(bucket)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "delete bucket: %s failed: %s\n", bucket, err.Error())

--- a/cmd/kv/cmd/delete_keys.go
+++ b/cmd/kv/cmd/delete_keys.go
@@ -23,7 +23,7 @@ If no bucket is provided, the key will be deleted from the default bucket.`,
 	Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		k, b := parseKey(args[0])
-		s := storage.NewEntityStorage(db, encryptionKey)
+		s := storage.NewEntityStorage(kvdb, "")
 		err := s.Delete(b, k)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "delete key: %s in bucket %s failed: %s\n", k, b, err.Error())

--- a/cmd/kv/cmd/get.go
+++ b/cmd/kv/cmd/get.go
@@ -21,14 +21,20 @@ If a bucket is not specified, the default bucket will be used.`,
 	Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		k, b := parseKey(args[0])
-		s := storage.NewEntityStorage(db, encryptionKey)
+
+		encKey, err := selectKey(encryptionKeys, b)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		s := storage.NewEntityStorage(kvdb, encKey)
 		v, err := s.Get(b, k)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "get key: `%s` failed: %s\n", k, err.Error())
 			os.Exit(1)
 		}
 		fmt.Printf("%s", v)
-
 	},
 }
 

--- a/cmd/kv/cmd/helpers.go
+++ b/cmd/kv/cmd/helpers.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
-	"os"
 	"strings"
 
+	"github.com/yousysadmin/kv/internal/enckeystore"
 	"github.com/yousysadmin/kv/pkg/encrypt"
 )
 
@@ -19,34 +18,51 @@ func parseKey(input string) (key string, bucket string) {
 	return input, defaultBucketName
 }
 
-func getEncryptKey(encryptKey string, encryptKeyFile string) (string, error) {
-	if encryptKey != "" {
-		if err := encrypt.ValidateAESKey(encryptKey); err != nil {
-			return "", fmt.Errorf("provided encryption key is invalid: %w", err)
+// loadAllKeys returns all keys in Encryption Key Store
+func loadAllKeys(storePath, encryptionKey string) (map[string]string, *enckeystore.EncryptionKeyStore, error) {
+	// if encryptionKey is set that validate and return as default
+	if encryptionKey != "" {
+		if err := encrypt.ValidateAESKey(encryptionKey); err != nil {
+			return nil, nil, fmt.Errorf("provided encryption key is invalid: %w", err)
 		}
-		return encryptKey, nil
+		return map[string]string{"default": encryptionKey}, nil, nil
 	}
 
-	data, err := os.ReadFile(encryptKeyFile)
-	if err == nil && len(strings.TrimSpace(string(data))) > 0 {
-		key := strings.TrimSpace(string(data))
-		if err := encrypt.ValidateAESKey(key); err == nil {
-			return key, nil
-		}
+	// Encryption Key Store init
+	ks := enckeystore.NewEncryptionKeyStore(storePath)
+	if err := ks.Load(); err != nil {
+		return nil, nil, fmt.Errorf("load key store: %w", err)
 	}
 
-	if !errors.Is(err, os.ErrNotExist) && err != nil {
-		return "", fmt.Errorf("failed to read key file: %w", err)
-	}
-
-	key, err := encrypt.GenerateRandomAESKey(encrypt.AES256)
+	// Ensure default, if not then will generate new one and save
+	created := !ks.HasKey("default")
+	def, err := ks.EnsureDefaultKey()
 	if err != nil {
-		return "", fmt.Errorf("failed to generate AES key: %w", err)
+		return nil, nil, fmt.Errorf("ensure default key: %w", err)
+	}
+	if created {
+		if err := ks.Save(); err != nil {
+			return nil, nil, fmt.Errorf("save key store: %w", err)
+		}
 	}
 
-	if err := os.WriteFile(encryptKeyFile, []byte(key), 0600); err != nil {
-		return "", fmt.Errorf("failed to write key file: %w", err)
+	keys := make(map[string]string, len(ks.Keys))
+	for b, k := range ks.Keys {
+		keys[b] = string(k)
 	}
+	// Ensure default is present
+	keys["default"] = string(def)
 
-	return key, nil
+	return keys, ks, nil
+}
+
+// selectKey chooses a key for a bucket from the Encryption Keys Store.
+func selectKey(keysStore map[string]string, bucket string) (string, error) {
+	if k, ok := keysStore[bucket]; ok && k != "" {
+		return k, nil
+	}
+	if def, ok := keysStore["default"]; ok && def != "" {
+		return def, nil
+	}
+	return "", fmt.Errorf("no key for bucket %q and no default key", bucket)
 }

--- a/cmd/kv/cmd/import_ssm.go
+++ b/cmd/kv/cmd/import_ssm.go
@@ -77,7 +77,13 @@ var importSsmCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		s := storage.NewEntityStorage(db, encryptionKey)
+		encKey, err := selectKey(encryptionKeys, importBucketName)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		s := storage.NewEntityStorage(kvdb, encKey)
 		for key, value := range secrets {
 			if importDryRun {
 				if importShowValues {

--- a/cmd/kv/cmd/list_buckets.go
+++ b/cmd/kv/cmd/list_buckets.go
@@ -17,7 +17,7 @@ var listBucketsCmd = &cobra.Command{
 
 This command retrieves and prints the names of all top-level buckets stored in the database.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		s := storage.NewEntityStorage(db, encryptionKey)
+		s := storage.NewEntityStorage(kvdb, "")
 		bl, err := s.ListBuckets()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "list bucketets: failed: %s\n", err.Error())

--- a/cmd/kv/cmd/list_keys.go
+++ b/cmd/kv/cmd/list_keys.go
@@ -30,7 +30,14 @@ It does not display values, only the stored keys.`,
 		} else {
 			bucket = args[0]
 		}
-		s := storage.NewEntityStorage(db, encryptionKey)
+
+		encKey, err := selectKey(encryptionKeys, bucket)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		s := storage.NewEntityStorage(kvdb, encKey)
 		v, err := s.List(bucket, withValues)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "list keys in bucket: `%s` failed: %s\n", bucket, err.Error())

--- a/internal/enckeystore/doc.go
+++ b/internal/enckeystore/doc.go
@@ -1,0 +1,131 @@
+// Package enckeystore provides a tiny, file-backed store for AES encryption keys,
+// organized by "bucket" name with a special fallback "default" key.
+//
+// # Overview
+//
+// A Store is bound to a single YAML file on disk and exposes a small API:
+//
+//   - Load / Save: read and write the store (atomic write with fsync; 0600 perms)
+//   - AddDefaultKey: set "default" once; does not replace if it already exists
+//   - EnsureDefaultKey: create a fresh AES-256 default if missing
+//   - AddKey: add a new, per-bucket key (no replacement allowed)
+//   - Get: return the key for a bucket or the valid "default" fallback
+//   - HasKey / ListBuckets: inspect what’s present
+//
+// All public methods are safe for concurrent use; the store guards internal
+// state with an RWMutex. Disk I/O is explicit—callers decide when to Load and Save.
+//
+// # Key material and validation
+//
+// Keys are represented as EncryptionKey (a string). All additions and reads that
+// surface keys validate via your encrypt package:
+//
+//   - EncryptionKey.Validate() -> uses encrypt.ValidateAESKey(string(k))
+//   - GenerateEncryptionKey()  -> uses encrypt.GenerateRandomAESKey(encrypt.AES256)
+//
+// If a provided key is invalid, the operation fails with a wrapped error.
+// Get() only returns keys that validate; otherwise it transparently tries
+// the "default" key (also validated) before failing.
+//
+// # Persistence format
+//
+// The YAML file looks like:
+//
+//	keys:
+//	  default: "<base64-or-hex-aes-key>"
+//	  photos:  "<base64-or-hex-aes-key>"
+//	  logs:    "<base64-or-hex-aes-key>"
+//
+// Unknown fields are rejected on Load() (yaml.KnownFields(true)), helping catch
+// typos and format drift.
+//
+// # Atomic writes & permissions
+//
+// Save() performs an atomic, durable write sequence:
+//
+//  1. write to a temp file in the same directory
+//  2. flush and fsync the temp file
+//  3. rename over the target path
+//  4. fsync the directory (best effort)
+//
+// The final file mode is 0600, and its parent directory is ensured (0700).
+// This minimizes partial writes and reduces exposure of key material.
+//
+// # Replacement policy
+//
+// AddKey() and AddDefaultKey() do not replace existing entries. Replacements
+// must be done manually by editing the on-disk YAML (or deleting and re-adding).
+// This is intentional to avoid accidental key rotation. EnsureDefaultKey()
+// never replaces an existing "default"—it only creates one if missing.
+//
+// # Example
+//
+// The following example shows a typical lifecycle: load (or initialize),
+// ensure a default key, add a bucket key, read it, and save.
+//
+//	import (
+//		"fmt"
+//		"log"
+//		"os"
+//		"path/filepath"
+//
+//		"github.com/yousysadmin/kv/pkg/enckeystore"
+//	)
+//
+//	func example() {
+//		// Choose a path (for demo, a file in the temp dir).
+//		path := filepath.Join(os.TempDir(), "keys.yaml")
+//
+//		store := enckeystore.NewEncryptionKeyStore(path)
+//
+//		// Load existing state; missing file is OK (treated as empty store).
+//		if err := store.Load(); err != nil {
+//			log.Fatalf("load: %v", err)
+//		}
+//
+//		// Ensure there's a valid default (generates AES-256 if absent).
+//		defKey, err := store.EnsureDefaultKey()
+//		if err != nil {
+//			log.Fatalf("ensure default: %v", err)
+//		}
+//		fmt.Println("default key exists:", defKey != "")
+//
+//		// Add a per-bucket key (no replacement if one already exists).
+//		k, err := enckeystore.GenerateEncryptionKey()
+//		if err != nil {
+//			log.Fatalf("generate: %v", err)
+//		}
+//		if err := store.AddKey("photos", k); err != nil {
+//			// If it already exists, this will error; that's expected by design.
+//			log.Printf("add key (photos): %v", err)
+//		}
+//
+//		// Read the key for a bucket (falls back to "default" if bucket missing).
+//		got, err := store.Get("photos")
+//		if err != nil {
+//			log.Fatalf("get: %v", err)
+//		}
+//		_ = got // use the key
+//
+//		// Persist current state atomically with secure perms.
+//		if err := store.Save(); err != nil {
+//			log.Fatalf("save: %v", err)
+//		}
+//	}
+//
+// # Error handling & invariants
+//
+//   - Load() returns nil on a missing file and resets unknown fields.
+//   - Get(bucket) fails if neither bucket nor a valid default are present.
+//   - EnsureDefaultKey() returns an error if an existing default is present but invalid,
+//     prompting a manual fix in the YAML (to avoid silent replacement).
+//   - AddKey/AddDefaultKey validate the provided key first and never replace.
+//
+// # Security reminders
+//
+//   - Keep the YAML file on a trusted filesystem; Save() enforces 0600 but your
+//     environment and backups still matter.
+//   - Consider process memory exposure if logging keys; avoid printing key values.
+//   - If you need rotation, design a deliberate process to edit the YAML and
+//     roll keys carefully across dependent systems.
+package enckeystore

--- a/internal/enckeystore/enckeystore.go
+++ b/internal/enckeystore/enckeystore.go
@@ -1,0 +1,266 @@
+package enckeystore
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/yousysadmin/kv/pkg/encrypt"
+	"gopkg.in/yaml.v3"
+)
+
+type EncryptionKey string
+
+// Validate ensures the AES key.
+func (k EncryptionKey) Validate() error {
+	if err := encrypt.ValidateAESKey(string(k)); err != nil {
+		return fmt.Errorf("invalid AES key: %w", err)
+	}
+	return nil
+}
+
+// GenerateEncryptionKey creates a new AES-256 key using your encrypt package.
+func GenerateEncryptionKey() (EncryptionKey, error) {
+	key, err := encrypt.GenerateRandomAESKey(encrypt.AES256)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate AES-256 key: %w", err)
+	}
+	return EncryptionKey(key), nil
+}
+
+type EncryptionKeyStore struct {
+	path string                   `yaml:"-"`
+	Keys map[string]EncryptionKey `yaml:"keys"`
+
+	mu sync.RWMutex
+}
+
+// NewEncryptionKeyStore creates an empty store bound to a file path.
+func NewEncryptionKeyStore(path string) *EncryptionKeyStore {
+	return &EncryptionKeyStore{
+		path: path,
+		Keys: make(map[string]EncryptionKey),
+	}
+}
+
+// Load reads keys from disk. Missing file just return is empty store.
+func (s *EncryptionKeyStore) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if s.Keys == nil {
+				s.Keys = make(map[string]EncryptionKey)
+			}
+			return nil
+		}
+		return err
+	}
+
+	type onDisk struct {
+		Keys map[string]EncryptionKey `yaml:"keys"`
+	}
+	var disk onDisk
+
+	dec := yaml.NewDecoder(strings.NewReader(string(b)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&disk); err != nil {
+		return fmt.Errorf("parse %s: %w", s.path, err)
+	}
+
+	if disk.Keys == nil {
+		disk.Keys = make(map[string]EncryptionKey)
+	}
+	s.Keys = disk.Keys
+	return nil
+}
+
+// ReLoad is an alias for Load.
+func (s *EncryptionKeyStore) ReLoad() error { return s.Load() }
+
+// Save writes to disk atomically with 0600 perms.
+func (s *EncryptionKeyStore) Save() error {
+	s.mu.RLock()
+	dump := struct {
+		Keys map[string]EncryptionKey `yaml:"keys"`
+	}{
+		Keys: s.copyKeysLocked(),
+	}
+	s.mu.RUnlock()
+
+	data, err := yaml.Marshal(&dump)
+	if err != nil {
+		return fmt.Errorf("yaml marshal: %w", err)
+	}
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	return atomicWriteFile(s.path, data, 0o600)
+}
+
+// atomicWriteFile writes to a temp file, fsyncs file & dir, then renames.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-keys-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+
+	w := bufio.NewWriter(tmp)
+	if _, err := w.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := w.Flush(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("flush temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temp -> %s: %w", path, err)
+	}
+
+	// fsync the directory to persist the rename on some filesystems
+	dirFD, err := os.Open(dir)
+	if err == nil {
+		_ = dirFD.Sync()
+		_ = dirFD.Close()
+	}
+	return nil
+}
+
+// Get returns the key for bucketName if present and valid,
+// else returns a valid "default" key if present. Otherwise error.
+func (s *EncryptionKeyStore) Get(bucketName string) (EncryptionKey, error) {
+	s.mu.RLock()
+	key, ok := s.Keys[bucketName]
+	def, hasDef := s.Keys["default"]
+	s.mu.RUnlock()
+
+	if ok && key != "" && key.Validate() == nil {
+		return key, nil
+	}
+	if hasDef && def != "" && def.Validate() == nil {
+		return def, nil
+	}
+	return "", fmt.Errorf("no valid encryption key for %q and no valid default", bucketName)
+}
+
+// AddKey inserts a new key for a bucket after validation.
+// If the bucket already has a key, it returns an error (no replacement allowed).
+func (s *EncryptionKeyStore) AddKey(bucketName string, key EncryptionKey) error {
+	if strings.TrimSpace(bucketName) == "" {
+		return fmt.Errorf("bucket name cannot be empty")
+	}
+	if err := key.Validate(); err != nil {
+		return fmt.Errorf("invalid encryption key for bucket %q: %w", bucketName, err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.Keys == nil {
+		s.Keys = make(map[string]EncryptionKey)
+	}
+	if _, exists := s.Keys[bucketName]; exists {
+		return fmt.Errorf("encryption key for bucket %q already exists; remove it from file to replace", bucketName)
+	}
+	s.Keys[bucketName] = key
+	return nil
+}
+
+// AddDefaultKey sets the "default" key if and only if it does not yet exist.
+// If default already exists, returns an error (no replacement allowed).
+// If key == "", a new AES-256 key is generated.
+func (s *EncryptionKeyStore) AddDefaultKey(key EncryptionKey) (EncryptionKey, error) {
+	if key == "" {
+		gen, err := GenerateEncryptionKey()
+		if err != nil {
+			return "", err
+		}
+		key = gen
+	}
+	if err := key.Validate(); err != nil {
+		return "", fmt.Errorf("invalid default key: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.Keys == nil {
+		s.Keys = make(map[string]EncryptionKey)
+	}
+	if _, exists := s.Keys["default"]; exists {
+		return "", fmt.Errorf(`"default" key already exists; remove it from file to replace`)
+	}
+	s.Keys["default"] = key
+	return key, nil
+}
+
+// EnsureDefaultKey creates and stores a default key only if missing.
+// Never replaces existing default.
+func (s *EncryptionKeyStore) EnsureDefaultKey() (EncryptionKey, error) {
+	s.mu.RLock()
+	def, exists := s.Keys["default"]
+	s.mu.RUnlock()
+	if exists {
+		if err := def.Validate(); err != nil {
+			// existing but invalid → user must fix file manually
+			return "", fmt.Errorf(`existing "default" key is invalid; remove/fix it in the file: %w`, err)
+		}
+		return def, nil
+	}
+	return s.AddDefaultKey("")
+}
+
+// HasKey reports true if the store currently holds any key for the bucket (no validation).
+func (s *EncryptionKeyStore) HasKey(bucketName string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.Keys[bucketName]
+	return ok
+}
+
+// ListBuckets returns bucket names in sorted order.
+func (s *EncryptionKeyStore) ListBuckets() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]string, 0, len(s.Keys))
+	for k := range s.Keys {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// copyKeysLocked clones s.Keys under read lock.
+func (s *EncryptionKeyStore) copyKeysLocked() map[string]EncryptionKey {
+	cp := make(map[string]EncryptionKey, len(s.Keys))
+	maps.Copy(cp, s.Keys)
+	return cp
+}

--- a/internal/enckeystore/enckeystore_test.go
+++ b/internal/enckeystore/enckeystore_test.go
@@ -1,0 +1,293 @@
+package enckeystore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// helper: create a fresh temp directory + file path for a store.
+func newTempStorePath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return filepath.Join(dir, "keys.yaml")
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load() on missing file = %v; want nil", err)
+	}
+	if s.Keys == nil || len(s.Keys) != 0 {
+		t.Fatalf("Keys after Load() on missing file = %#v; want empty map", s.Keys)
+	}
+}
+
+func TestSaveAndLoadRoundTrip(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	// Ensure default
+	def, err := s.EnsureDefaultKey()
+	if err != nil {
+		t.Fatalf("EnsureDefaultKey() = %v", err)
+	}
+	if err := def.Validate(); err != nil {
+		t.Fatalf("default key Validate() = %v", err)
+	}
+
+	// Add a bucket key
+	k, err := GenerateEncryptionKey()
+	if err != nil {
+		t.Fatalf("GenerateEncryptionKey() = %v", err)
+	}
+	if err := s.AddKey("photos", k); err != nil {
+		t.Fatalf("AddKey(photos) = %v", err)
+	}
+
+	// Persist
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save() = %v", err)
+	}
+
+	// Load into a fresh store and compare
+	s2 := NewEncryptionKeyStore(path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("second Load() = %v", err)
+	}
+
+	if got := len(s2.Keys); got != len(s.Keys) {
+		t.Fatalf("len(Keys) = %d; want %d", got, len(s.Keys))
+	}
+	if s2.Keys["default"] == "" || s2.Keys["photos"] == "" {
+		t.Fatalf("missing keys after reload: %#v", s2.Keys)
+	}
+}
+
+func TestGetBucketAndFallback(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	// default
+	def, err := s.AddDefaultKey("")
+	if err != nil {
+		t.Fatalf("AddDefaultKey(\"\") = %v", err)
+	}
+	// specific
+	bk, err := GenerateEncryptionKey()
+	if err != nil {
+		t.Fatalf("GenerateEncryptionKey() = %v", err)
+	}
+	if err := s.AddKey("logs", bk); err != nil {
+		t.Fatalf("AddKey(logs) = %v", err)
+	}
+
+	// bucket present
+	got, err := s.Get("logs")
+	if err != nil {
+		t.Fatalf("Get(logs) error = %v", err)
+	}
+	if got != bk {
+		t.Fatalf("Get(logs) = %q; want %q", got, bk)
+	}
+
+	// bucket missing -> fallback to default
+	got2, err := s.Get("missing")
+	if err != nil {
+		t.Fatalf("Get(missing) error = %v", err)
+	}
+	if got2 != def {
+		t.Fatalf("Get(missing) fallback = %q; want default %q", got2, def)
+	}
+}
+
+func TestAddKeyNoReplace(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	k1, _ := GenerateEncryptionKey()
+	if err := s.AddKey("b", k1); err != nil {
+		t.Fatalf("AddKey first = %v", err)
+	}
+	k2, _ := GenerateEncryptionKey()
+	if err := s.AddKey("b", k2); err == nil {
+		t.Fatalf("AddKey replace = nil; want error")
+	}
+}
+
+func TestAddDefaultNoReplace(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	if _, err := s.AddDefaultKey(""); err != nil {
+		t.Fatalf("AddDefaultKey first = %v", err)
+	}
+	if _, err := s.AddDefaultKey(""); err == nil {
+		t.Fatalf("AddDefaultKey replace = nil; want error")
+	}
+}
+
+func TestEnsureDefaultInvalidExisting(t *testing.T) {
+	path := newTempStorePath(t)
+
+	// Write an invalid default key directly to disk (bypass validation)
+	type onDisk struct {
+		Keys map[string]EncryptionKey `yaml:"keys"`
+	}
+	bad := onDisk{
+		Keys: map[string]EncryptionKey{
+			"default": "too-short-or-wrong-format",
+		},
+	}
+	raw, err := yaml.Marshal(&bad)
+	if err != nil {
+		t.Fatalf("yaml marshal = %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write = %v", err)
+	}
+
+	s := NewEncryptionKeyStore(path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if _, err := s.EnsureDefaultKey(); err == nil {
+		t.Fatalf("EnsureDefaultKey with invalid existing default = nil; want error")
+	} else if !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("EnsureDefaultKey error = %v; want contains 'invalid'", err)
+	}
+}
+
+func TestListBucketsSorted(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	// Insert out of order
+	ka, _ := GenerateEncryptionKey()
+	kb, _ := GenerateEncryptionKey()
+	if _, err := s.AddDefaultKey(""); err != nil {
+		t.Fatalf("AddDefaultKey = %v", err)
+	}
+	if err := s.AddKey("zeta", kb); err != nil {
+		t.Fatalf("AddKey(zeta) = %v", err)
+	}
+	if err := s.AddKey("alpha", ka); err != nil {
+		t.Fatalf("AddKey(alpha) = %v", err)
+	}
+
+	got := s.ListBuckets()
+	want := []string{"alpha", "default", "zeta"}
+	if len(got) != len(want) {
+		t.Fatalf("ListBuckets len = %d; want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ListBuckets[%d] = %q; want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSavePermissions(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	if _, err := s.AddDefaultKey(""); err != nil {
+		t.Fatalf("AddDefaultKey = %v", err)
+	}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save() = %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat file = %v", err)
+	}
+	mode := info.Mode().Perm()
+	// Expect file to be owner-read/write only (0600). We allow umask-insensitive check:
+	if mode&0o077 != 0 {
+		t.Fatalf("file perms = %o; want no group/other bits set", mode)
+	}
+}
+
+func TestLoadRejectsUnknownFields(t *testing.T) {
+	path := newTempStorePath(t)
+
+	yamlWithUnknown := `
+keys:
+  default: "abc"
+unknownField: "boom"
+`
+	if err := os.WriteFile(path, []byte(yamlWithUnknown), 0o600); err != nil {
+		t.Fatalf("write = %v", err)
+	}
+
+	s := NewEncryptionKeyStore(path)
+	err := s.Load()
+	if err == nil {
+		t.Fatalf("Load() = nil; want error due to unknown field")
+	}
+	if !strings.Contains(err.Error(), "unknown field") && !strings.Contains(err.Error(), "field") {
+		t.Fatalf("Load() error = %v; want 'unknown field'", err)
+	}
+}
+
+func TestGetNoDefaultNoBucket(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	_, err := s.Get("missing")
+	if err == nil {
+		t.Fatalf("Get() without bucket and default = nil; want error")
+	}
+}
+
+func TestHasKey(t *testing.T) {
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	if s.HasKey("x") {
+		t.Fatalf("HasKey(x) = true; want false")
+	}
+	k, _ := GenerateEncryptionKey()
+	if err := s.AddKey("x", k); err != nil {
+		t.Fatalf("AddKey(x) = %v", err)
+	}
+	if !s.HasKey("x") {
+		t.Fatalf("HasKey(x) = false; want true")
+	}
+}
+
+func TestAtomicWriteOverwritesFully(t *testing.T) {
+	// This test exercises that Save writes complete content,
+	// by saving then re-loading and checking both keys exist.
+	path := newTempStorePath(t)
+	s := NewEncryptionKeyStore(path)
+
+	if _, err := s.AddDefaultKey(""); err != nil {
+		t.Fatalf("AddDefaultKey = %v", err)
+	}
+	k, _ := GenerateEncryptionKey()
+	if err := s.AddKey("bucket", k); err != nil {
+		t.Fatalf("AddKey(bucket) = %v", err)
+	}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save() = %v", err)
+	}
+
+	// Overwrite with new state that still must be complete
+	s2 := NewEncryptionKeyStore(path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if _, ok := s2.Keys["default"]; !ok {
+		t.Fatalf("after reload, missing 'default' key")
+	}
+	if _, ok := s2.Keys["bucket"]; !ok {
+		t.Fatalf("after reload, missing 'bucket' key")
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"path/filepath"
+	"syscall"
+)
+
+// IsOnNetworkStorage() performs a syscall.Statfs on the parent directory and
+// checks known magic constants for NFS/SMB-like filesystems. This is a heuristic
+// intended for operators who might care about fsync semantics on network mounts..
+func IsOnNetworkStorage(path string) (bool, error) {
+	if path == "" {
+		return false, nil
+	}
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(filepath.Dir(path), &st); err != nil {
+		return false, err
+	}
+	const (
+		NFS_SUPER_MAGIC  = 0x6969
+		CIFS_SUPER_MAGIC = 0xFF534D42
+		SMB2_MAGIC       = 0xFE534D42
+	)
+	switch uint64(st.Type) {
+	case NFS_SUPER_MAGIC, CIFS_SUPER_MAGIC, SMB2_MAGIC:
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,37 @@
+package utils_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"github.com/yousysadmin/kv/internal/utils"
+)
+
+// helper: create a fresh temp directory + file path for a store.
+func newTempStorePath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return filepath.Join(dir, "test.txt")
+}
+
+func TestIsOnNetworkStorage(t *testing.T) {
+	// check os, windows not sopported.
+	if runtime.GOOS == "windows" {
+		t.Skip("syscall.Statfs not supported on Windows in this test")
+	}
+	path := newTempStorePath(t)
+
+	onNet, err := utils.IsOnNetworkStorage(path)
+	if err != nil {
+		t.Fatalf("IsOnNetworkStorage() = %v", err)
+	}
+	_ = onNet
+
+	// Statfs type is readable.
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(filepath.Dir(path), &st); err != nil {
+		t.Fatalf("Statfs(dir) = %v", err)
+	}
+}


### PR DESCRIPTION
## BREAKING CHANGES!

- updated the process of working with encryption keys
- the add command is now divided into two subcommands - `key` and `baсket`

key file shoud de have format
```yaml
keys:
  default: <key>
  my-bucket: <key>
```

the default key will be used for all buckets without a separate key
the key with the bucket name will be used for a specific bucket

## Migration
Edit the current key file and add the current key as the default key
```yaml
keys:
  default: <key>
```